### PR TITLE
[PR-15] 템플릿 메소드로 사용할 Base Class 추가

### DIFF
--- a/buildSrc/src/main/java/Dependency.kt
+++ b/buildSrc/src/main/java/Dependency.kt
@@ -52,6 +52,8 @@ object Versions {
     const val glideOkHttpIntegration: String = "4.9.0"
     const val koin: String = "2.0.1"
     const val lottie: String = "3.4.0"
+    const val logger: String = "2.2.0"
+
     const val junit: String = "4.12"
     const val junitExt: String = "1.1.1"
     const val espresso: String = "3.2.0"
@@ -92,6 +94,7 @@ object Libs {
     const val koinScope = "org.koin:koin-android-scope:${Versions.koin}"
     const val koinViewModel = "org.koin:koin-android-viewmodel:${Versions.koin}"
     const val lottie = "com.airbnb.android:lottie:${Versions.lottie}"
+    const val logger = "com.orhanobut:logger:${Versions.logger}"
 }
 
 object TestLibs {

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -14,6 +14,8 @@ android {
         targetSdkVersion(Apps.targetSdk)
         versionCode = Apps.versionCode
         versionName = Apps.versionName
+
+        buildConfigField("String", "BASE_URL", "\"\"")
     }
 
     buildTypes {
@@ -45,8 +47,27 @@ dependencies {
     implementation(Libs.kotlin)
     implementation(Libs.coreKtx)
     implementation(Libs.appcompat)
+
+    // RxJava
     implementation(Libs.rxJava2)
     implementation(Libs.rxAndroid)
     implementation(Libs.rxKotlin)
+
+    // Retrofit, OkHttp, Gson
+    implementation(Libs.retrofit2)
+    implementation(Libs.okHttp3)
+    implementation(Libs.converterGson)
+    implementation(Libs.adapterRxJava2)
+    implementation(Libs.gson)
+
+    // Room
+    implementation(Libs.roomRuntime)
+    implementation(Libs.roomKtx)
+    implementation(Libs.roomRxJava2)
+    kapt(Libs.roomCompiler)
+
+    // Logger
+    implementation(Libs.logger)
+
     implementation(TestLibs.junit)
 }

--- a/data/src/main/kotlin/kr/ohyung/data/Api.kt
+++ b/data/src/main/kotlin/kr/ohyung/data/Api.kt
@@ -1,0 +1,6 @@
+package kr.ohyung.data
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+interface Api

--- a/data/src/main/kotlin/kr/ohyung/data/Request.kt
+++ b/data/src/main/kotlin/kr/ohyung/data/Request.kt
@@ -1,0 +1,6 @@
+package kr.ohyung.data
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+interface Request

--- a/data/src/main/kotlin/kr/ohyung/data/Response.kt
+++ b/data/src/main/kotlin/kr/ohyung/data/Response.kt
@@ -1,0 +1,6 @@
+package kr.ohyung.data
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+interface Response

--- a/data/src/main/kotlin/kr/ohyung/data/RoomObject.kt
+++ b/data/src/main/kotlin/kr/ohyung/data/RoomObject.kt
@@ -1,0 +1,6 @@
+package kr.ohyung.data
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+interface RoomObject

--- a/data/src/main/kotlin/kr/ohyung/data/network/RetrofitManager.kt
+++ b/data/src/main/kotlin/kr/ohyung/data/network/RetrofitManager.kt
@@ -1,0 +1,66 @@
+package kr.ohyung.data.network
+
+import kr.ohyung.data.BuildConfig
+import com.orhanobut.logger.Logger
+import okhttp3.*
+import org.json.JSONException
+import org.json.JSONObject
+import retrofit2.Retrofit
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+object RetrofitManager {
+
+    private const val TAG: String = "RetrofitManager"
+
+    private const val CONNECT_TIMEOUT: Long = 30L
+    private const val WRITE_TIMEOUT: Long = 30L
+    private const val READ_TIMEOUT: Long = 30L
+
+    fun <T> create(service: Class<T>): T =
+        getRetrofit().create(service)
+
+    private fun getRetrofit() : Retrofit =
+        Retrofit.Builder()
+            .baseUrl(BuildConfig.BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+            .client(getOkHttpClient())
+            .build()
+
+    private fun getOkHttpClient(): OkHttpClient =
+        OkHttpClient.Builder()
+            .retryOnConnectionFailure(true)
+            .connectTimeout(CONNECT_TIMEOUT, TimeUnit.SECONDS)
+            .writeTimeout(WRITE_TIMEOUT, TimeUnit.SECONDS)
+            .readTimeout(READ_TIMEOUT, TimeUnit.SECONDS)
+            .addInterceptor(getLoggerInterceptor())
+            .build()
+
+    private fun getLoggerInterceptor(): Interceptor = object: Interceptor {
+
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val response: Response = chain.proceed(chain.request().newBuilder().build())
+            val request: Request = chain.request().newBuilder().build()
+            val body: String = response.body?.string() ?: ""
+            try {
+                JSONObject(body)
+                Logger.t(TAG).json(body)
+            } catch (e: JSONException) {
+                Logger.t(TAG).d(body)
+            } finally {
+                Logger.d("REQUEST : $request")
+                return response.newBuilder()
+                    .body(
+                        ResponseBody.create(
+                        response.body?.contentType(),
+                        body))
+                    .build()
+            }
+        }
+    }
+}

--- a/domain/src/main/kotlin/kr/ohyung/domain/Entity.kt
+++ b/domain/src/main/kotlin/kr/ohyung/domain/Entity.kt
@@ -1,0 +1,6 @@
+package kr.ohyung.domain
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+interface Entity

--- a/domain/src/main/kotlin/kr/ohyung/domain/Repository.kt
+++ b/domain/src/main/kotlin/kr/ohyung/domain/Repository.kt
@@ -1,0 +1,6 @@
+package kr.ohyung.domain
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+interface Repository

--- a/domain/src/main/kotlin/kr/ohyung/domain/UseCase.kt
+++ b/domain/src/main/kotlin/kr/ohyung/domain/UseCase.kt
@@ -1,0 +1,6 @@
+package kr.ohyung.domain
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+interface UseCase

--- a/domain/src/main/kotlin/kr/ohyung/domain/entity/MockEntity.kt
+++ b/domain/src/main/kotlin/kr/ohyung/domain/entity/MockEntity.kt
@@ -1,0 +1,12 @@
+package kr.ohyung.domain.entity
+
+import kr.ohyung.domain.Entity
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+data class MockEntity(
+    val id: Int,
+    val title: String,
+    val description: String
+) : Entity

--- a/domain/src/main/kotlin/kr/ohyung/domain/exception/MockException.kt
+++ b/domain/src/main/kotlin/kr/ohyung/domain/exception/MockException.kt
@@ -1,0 +1,6 @@
+package kr.ohyung.domain.exception
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+class MockException : Exception()

--- a/domain/src/main/kotlin/kr/ohyung/domain/repository/MockRepository.kt
+++ b/domain/src/main/kotlin/kr/ohyung/domain/repository/MockRepository.kt
@@ -1,0 +1,13 @@
+package kr.ohyung.domain.repository
+
+import io.reactivex.Single
+import kr.ohyung.domain.Repository
+import kr.ohyung.domain.entity.MockEntity
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+interface MockRepository : Repository {
+
+    fun mock(): Single<MockEntity>
+}

--- a/domain/src/main/kotlin/kr/ohyung/domain/usecase/BaseUseCase.kt
+++ b/domain/src/main/kotlin/kr/ohyung/domain/usecase/BaseUseCase.kt
@@ -1,0 +1,23 @@
+package kr.ohyung.domain.usecase
+
+import io.reactivex.disposables.CompositeDisposable
+import kr.ohyung.domain.UseCase
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+abstract class BaseUseCase : UseCase {
+
+    protected val compositeDisposable = CompositeDisposable()
+
+    protected fun dispose() {
+        if(compositeDisposable.isDisposed.not()){
+            compositeDisposable.dispose()
+        }
+    }
+
+    protected fun clear() {
+        compositeDisposable.clear()
+    }
+
+}

--- a/domain/src/main/kotlin/kr/ohyung/domain/usecase/CompletableUseCase.kt
+++ b/domain/src/main/kotlin/kr/ohyung/domain/usecase/CompletableUseCase.kt
@@ -1,0 +1,27 @@
+package kr.ohyung.domain.usecase
+
+import io.reactivex.Completable
+import io.reactivex.Scheduler
+import io.reactivex.observers.DisposableCompletableObserver
+import io.reactivex.rxkotlin.addTo
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+abstract class CompletableUseCase(
+    private val executorScheduler: Scheduler,
+    private val postExecutionScheduler: Scheduler
+) : BaseUseCase() {
+
+    protected abstract fun buildUseCaseCompletable(): Completable
+
+    fun execute(observer: DisposableCompletableObserver) {
+        if(compositeDisposable.isDisposed.not()) {
+            buildUseCaseCompletable()
+                .subscribeOn(executorScheduler)
+                .observeOn(postExecutionScheduler)
+                .subscribeWith(observer)
+                .addTo(compositeDisposable)
+        }
+    }
+}

--- a/domain/src/main/kotlin/kr/ohyung/domain/usecase/SingleUseCase.kt
+++ b/domain/src/main/kotlin/kr/ohyung/domain/usecase/SingleUseCase.kt
@@ -1,0 +1,26 @@
+package kr.ohyung.domain.usecase
+
+import io.reactivex.Scheduler
+import io.reactivex.Single
+import io.reactivex.observers.DisposableSingleObserver
+import io.reactivex.rxkotlin.addTo
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+abstract class SingleUseCase<T>(
+    private val executorScheduler: Scheduler,
+    private val postExecutionScheduler: Scheduler
+) : BaseUseCase() {
+
+    protected abstract fun buildUseCaseSingle(): Single<T>
+
+    fun execute(observer: DisposableSingleObserver<T>) {
+        if(compositeDisposable.isDisposed.not())
+            buildUseCaseSingle()
+                .subscribeOn(executorScheduler)
+                .observeOn(postExecutionScheduler)
+                .subscribeWith(observer)
+                .addTo(compositeDisposable)
+    }
+}

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -73,13 +73,6 @@ dependencies {
     implementation(Libs.recyclerview)
     implementation(Libs.cardview)
 
-    // Retrofit, OkHttp, Gson
-    implementation(Libs.retrofit2)
-    implementation(Libs.okHttp3)
-    implementation(Libs.converterGson)
-    implementation(Libs.adapterRxJava2)
-    implementation(Libs.gson)
-
     // RxJava2
     implementation(Libs.rxJava2)
     implementation(Libs.rxAndroid)
@@ -92,12 +85,6 @@ dependencies {
     implementation(Libs.lifeCycleCommonJava8)
     implementation(Libs.fragmentExt)
     implementation(Libs.activityExt)
-
-    // Room
-    implementation(Libs.roomRuntime)
-    implementation(Libs.roomKtx)
-    implementation(Libs.roomRxJava2)
-    kapt(Libs.roomCompiler)
 
     // Glide
     implementation(Libs.glide)
@@ -112,6 +99,9 @@ dependencies {
 
     // Lottie
     implementation(Libs.lottie)
+
+    // Logger
+    implementation(Libs.logger)
 
     // Testing
     testImplementation(TestLibs.junit)

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -3,19 +3,25 @@
     package="kr.ohyung.weather">
 
     <application
+        android:name=".WeatherApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+
+        <activity
+            android:name=".MainActivity"
+            android:launchMode="singleTop"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
     </application>
 
 </manifest>

--- a/presentation/src/main/kotlin/kr/ohyung/weather/MainActivity.kt
+++ b/presentation/src/main/kotlin/kr/ohyung/weather/MainActivity.kt
@@ -1,11 +1,36 @@
 package kr.ohyung.weather
 
-import androidx.appcompat.app.AppCompatActivity
-import android.os.Bundle
+import android.content.Context
+import androidx.lifecycle.ViewModelProvider
+import kr.ohyung.weather.base.BaseActivity
+import kr.ohyung.weather.databinding.ActivityMainBinding
+import org.jetbrains.anko.intentFor
+import org.jetbrains.anko.singleTop
 
-class MainActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+class MainActivity : BaseActivity<ActivityMainBinding, MainViewModel>() {
+
+    companion object {
+
+        fun start(context: Context) =
+            context.startActivity(
+                context.intentFor<MainActivity>()
+                    .singleTop()
+            )
     }
+
+    override val resourceId: Int
+        get() = R.layout.activity_main
+
+    override val viewModel: MainViewModel by lazy {
+        ViewModelProvider(this).get(MainViewModel::class.java)
+    }
+
+    override fun setBindingVariable() {
+        binding.viewModel = viewModel
+    }
+
+    override fun doOnStart() {
+        /* explicitly empty */
+    }
+
 }

--- a/presentation/src/main/kotlin/kr/ohyung/weather/MainActivity.kt
+++ b/presentation/src/main/kotlin/kr/ohyung/weather/MainActivity.kt
@@ -1,11 +1,11 @@
 package kr.ohyung.weather
 
 import android.content.Context
-import androidx.lifecycle.ViewModelProvider
 import kr.ohyung.weather.base.BaseActivity
 import kr.ohyung.weather.databinding.ActivityMainBinding
 import org.jetbrains.anko.intentFor
 import org.jetbrains.anko.singleTop
+import org.koin.android.viewmodel.ext.android.viewModel
 
 class MainActivity : BaseActivity<ActivityMainBinding, MainViewModel>() {
 
@@ -21,9 +21,7 @@ class MainActivity : BaseActivity<ActivityMainBinding, MainViewModel>() {
     override val resourceId: Int
         get() = R.layout.activity_main
 
-    override val viewModel: MainViewModel by lazy {
-        ViewModelProvider(this).get(MainViewModel::class.java)
-    }
+    override val viewModel: MainViewModel by viewModel()
 
     override fun setBindingVariable() {
         binding.viewModel = viewModel

--- a/presentation/src/main/kotlin/kr/ohyung/weather/MainViewModel.kt
+++ b/presentation/src/main/kotlin/kr/ohyung/weather/MainViewModel.kt
@@ -1,0 +1,10 @@
+package kr.ohyung.weather
+
+import kr.ohyung.weather.base.BaseViewModel
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/08.
+ */
+class MainViewModel : BaseViewModel() {
+
+}

--- a/presentation/src/main/kotlin/kr/ohyung/weather/UiState.kt
+++ b/presentation/src/main/kotlin/kr/ohyung/weather/UiState.kt
@@ -1,0 +1,6 @@
+package kr.ohyung.weather
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+interface UiState

--- a/presentation/src/main/kotlin/kr/ohyung/weather/WeatherApplication.kt
+++ b/presentation/src/main/kotlin/kr/ohyung/weather/WeatherApplication.kt
@@ -1,6 +1,7 @@
 package kr.ohyung.weather
 
 import android.app.Application
+import org.koin.android.ext.android.inject
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
@@ -16,7 +17,7 @@ class WeatherApplication : Application() {
         startKoin {
             androidLogger()
             androidContext(this@WeatherApplication)
-
+            modules(modules = kr.ohyung.weather.inject.modules)
         }
     }
 }

--- a/presentation/src/main/kotlin/kr/ohyung/weather/WeatherApplication.kt
+++ b/presentation/src/main/kotlin/kr/ohyung/weather/WeatherApplication.kt
@@ -1,0 +1,22 @@
+package kr.ohyung.weather
+
+import android.app.Application
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.core.context.startKoin
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/08.
+ */
+class WeatherApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        startKoin {
+            androidLogger()
+            androidContext(this@WeatherApplication)
+
+        }
+    }
+}

--- a/presentation/src/main/kotlin/kr/ohyung/weather/base/BaseActivity.kt
+++ b/presentation/src/main/kotlin/kr/ohyung/weather/base/BaseActivity.kt
@@ -1,0 +1,51 @@
+package kr.ohyung.weather.base
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/08.
+ */
+abstract class BaseActivity<T: ViewDataBinding, VM: BaseViewModel> : AppCompatActivity() {
+
+    abstract val resourceId: Int
+
+    protected lateinit var binding: T
+
+    abstract val viewModel: VM
+
+    abstract fun setBindingVariable()
+
+    abstract fun doOnStart()
+
+    open fun setRecyclerView() { /* explicitly empty */ }
+
+    open fun observeData() { /* explicitly empty */ }
+
+    open fun setListener() { /* explicitly empty */ }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setBinding()
+        setBindingVariable()
+        observeData()
+        setRecyclerView()
+        setListener()
+        doOnStart()
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressed()
+        return false
+    }
+
+    private fun setBinding() {
+        binding = DataBindingUtil.setContentView(this, resourceId)
+        binding.lifecycleOwner = this
+    }
+
+    protected fun setToolbar(title: String) { /* explicitly empty */ }
+
+}

--- a/presentation/src/main/kotlin/kr/ohyung/weather/base/BaseAdapter.kt
+++ b/presentation/src/main/kotlin/kr/ohyung/weather/base/BaseAdapter.kt
@@ -1,0 +1,15 @@
+package kr.ohyung.weather.base
+
+import androidx.recyclerview.widget.RecyclerView
+import kr.ohyung.domain.Entity
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+abstract class BaseAdapter<M: Entity> : RecyclerView.Adapter<BaseViewHolder<M>>() {
+
+    open fun init() { /* explicitly empty */ }
+
+    open fun update() { /* explicitly empty */ }
+
+}

--- a/presentation/src/main/kotlin/kr/ohyung/weather/base/BaseViewHolder.kt
+++ b/presentation/src/main/kotlin/kr/ohyung/weather/base/BaseViewHolder.kt
@@ -1,0 +1,16 @@
+package kr.ohyung.weather.base
+
+import androidx.databinding.ViewDataBinding
+import androidx.recyclerview.widget.RecyclerView
+import kr.ohyung.domain.Entity
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+abstract class BaseViewHolder<M: Entity>(
+    private val binding: ViewDataBinding
+) : RecyclerView.ViewHolder(binding.root) {
+
+    abstract fun onBind(item: M)
+
+}

--- a/presentation/src/main/kotlin/kr/ohyung/weather/base/BaseViewModel.kt
+++ b/presentation/src/main/kotlin/kr/ohyung/weather/base/BaseViewModel.kt
@@ -1,0 +1,21 @@
+package kr.ohyung.weather.base
+
+import androidx.lifecycle.ViewModel
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.disposables.Disposable
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/08.
+ */
+abstract class BaseViewModel : ViewModel() {
+
+    private val compositeDisposable = CompositeDisposable()
+
+    override fun onCleared() {
+        compositeDisposable.clear()
+        super.onCleared()
+    }
+
+    fun Disposable.addDisposable() = compositeDisposable.add(this)
+
+}

--- a/presentation/src/main/kotlin/kr/ohyung/weather/inject/inject.kt
+++ b/presentation/src/main/kotlin/kr/ohyung/weather/inject/inject.kt
@@ -1,5 +1,7 @@
 package kr.ohyung.weather.inject
 
+import kr.ohyung.weather.MainViewModel
+import org.koin.android.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 /**
@@ -11,7 +13,7 @@ private val appModules = module {
 }
 
 private val viewModelModules = module {
-    /* explicitly empty */
+    viewModel { MainViewModel() }
 }
 
 private val apiModule = module {

--- a/presentation/src/main/kotlin/kr/ohyung/weather/inject/inject.kt
+++ b/presentation/src/main/kotlin/kr/ohyung/weather/inject/inject.kt
@@ -1,0 +1,21 @@
+package kr.ohyung.weather.inject
+
+import org.koin.dsl.module
+
+/**
+ * Created by Lee Oh Hyoung on 2020/07/09.
+ */
+
+private val appModules = module {
+    /* explicitly empty */
+}
+
+private val viewModelModules = module {
+    /* explicitly empty */
+}
+
+private val apiModule = module {
+    /* explicitly empty */
+}
+
+val modules = listOf(appModules, viewModelModules, apiModule)

--- a/presentation/src/main/res/layout/activity_main.xml
+++ b/presentation/src/main/res/layout/activity_main.xml
@@ -1,18 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <data>
+        <variable
+            name="viewModel"
+            type="kr.ohyung.weather.MainViewModel" />
+    </data>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".MainActivity">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Hello World!"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>


### PR DESCRIPTION
# PULL REQUEST

## 설명
Presentation, Data, Domain 레이어 에서 사용할 Template Class를 추가합니다.

## 작업사항
- [x] 3개의 모듈에서 사용할 Mark Interface 추가 - Entity, Repository, UseCase, Api, Request, Response, RoomObject, UiState
- [x] Presentation - BaseActivity, BaseFragment, BaseViewModel, BaseRecyclerView, BaseViewHolder, Application, Koin Modules
- [x] Data - Room/Retrofit 관련 클래스
- [x] Domain - BaseUseCase, SingleUseCase, CompletableUseCase


## 링크
https://jdm.kr/blog/116

## 스크린샷
<p>
	<img src="", width="300" />
</p>


## PR 타입
- [x] Feature
- [ ] Patch
- [ ] Hotfix
- [ ] Release
- [ ] Documentation
- [ ] Refactoring
